### PR TITLE
filename

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -143,12 +143,15 @@ export async function startClient(
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
       { scheme: "file", language: "codecov" },
+      { pattern: "**/.codecov.yml" },
       { pattern: "**/codecov.yml" },
       { pattern: "**/codecov.yaml" },
     ],
     synchronize: {
       configurationSection: "codecov",
       fileEvents: [
+        workspace.createFileSystemWatcher("**/.codecov.yml"),
+        workspace.createFileSystemWatcher(".codecov.yml"),
         workspace.createFileSystemWatcher("**/codecov.yml"),
         workspace.createFileSystemWatcher("codecov.yml"),
         workspace.createFileSystemWatcher("**/codecov.yaml"),


### PR DESCRIPTION
Hi!  I'm a big fan of codecov and was excited to find your VS Code extension today.  The repo I'm working in uses a slightly different filename (`.codecov.yml`) which doesn't seem supported.  Ideally, there would be a configurable setting to control this...I have no idea how to implement that, but here's a quick fix if you're open to it?