### PR TITLE
feat(coverage): Add support for custom colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,19 +116,19 @@
         "codecov.coverage.colors.covered": {
           "type": "string",
           "default": "rgb(33,181,119)",
-          "description": "The CSS color Codecov should use for covered lines.",
+          "description": "The CSS color Codecov should use for covered lines (e.g., green, hsl(120deg 100% 50%), #00FF00).",
           "order": 1
         },
         "codecov.coverage.colors.partial": {
           "type": "string",
           "default": "rgb(244,176,27)",
-          "description": "The CSS color Codecov should use for partial lines.",
+          "description": "The CSS color Codecov should use for partial lines (e.g., green, hsl(120deg 100% 50%), #00FF00).",
           "order": 2
         },
         "codecov.coverage.colors.missed": {
           "type": "string",
           "default": "rgb(245,32,32)",
-          "description": "The CSS color Codecov should use for missed lines.",
+          "description": "The CSS color Codecov should use for missed lines (e.g., green, hsl(120deg 100% 50%), #00FF00).",
           "order": 3
         },
         "codecov.api.gitProvider": {

--- a/package.json
+++ b/package.json
@@ -113,19 +113,37 @@
           "description": "Toggle Codecov line coverage decorations.",
           "order": 0
         },
+        "codecov.coverage.colors.covered": {
+          "type": "string",
+          "default": "rgb(33,181,119)",
+          "description": "The CSS color Codecov should use for covered lines.",
+          "order": 1
+        },
+        "codecov.coverage.colors.partial": {
+          "type": "string",
+          "default": "rgb(244,176,27)",
+          "description": "The CSS color Codecov should use for partial lines.",
+          "order": 2
+        },
+        "codecov.coverage.colors.missed": {
+          "type": "string",
+          "default": "rgb(245,32,32)",
+          "description": "The CSS color Codecov should use for missed lines.",
+          "order": 3
+        },
         "codecov.api.gitProvider": {
           "type": "string",
           "default": "github",
           "enum": ["github", "github_enterprise", "gitlab", "gitlab_enterprise", "bitbucket", "bitbucket_server"],
           "description": "Where are your repositories hosted?",
-          "order": 1
+          "order": 4
         },
         "codecov.api.url": {
           "type": "string",
           "default": "https://api.codecov.io",
           "format": "url",
           "description": "If you're self-hosting Codecov, update this to point to your self-hosted API.",
-          "order": 2
+          "order": 5
         }
       }
     }

--- a/src/coverage/coverage.ts
+++ b/src/coverage/coverage.ts
@@ -22,10 +22,12 @@ type Coverage =
     }
   | undefined;
 
-const Colors = {
-  covered: "rgb(33,181,119)",
-  partial: "rgb(244,176,27)",
-  missed: "rgb(245,32,32)",
+const config = workspace.getConfiguration("codecov");
+
+const Colors: Record<"covered" | "partial" | "missed", string> = {
+  covered: config.get("coverage.colors.covered") || "rgb(33,181,119)",
+  partial: config.get("coverage.colors.partial") || "rgb(244,176,27)",
+  missed: config.get("coverage.colors.missed") || "rgb(245,32,32)",
 } as const;
 
 const Icons = {
@@ -89,8 +91,6 @@ export function activateCoverage(context: ExtensionContext) {
     if (!activeEditor) {
       return;
     }
-
-    const config = workspace.getConfiguration("codecov");
 
     const enabled = config.get("coverage.enabled");
     if (!enabled) return;

--- a/src/coverage/coverage.ts
+++ b/src/coverage/coverage.ts
@@ -24,7 +24,7 @@ type Coverage =
 
 const config = workspace.getConfiguration("codecov");
 
-const Colors: Record<"covered" | "partial" | "missed", string> = {
+const Colors = {
   covered: config.get("coverage.colors.covered") || "rgb(33,181,119)",
   partial: config.get("coverage.colors.partial") || "rgb(244,176,27)",
   missed: config.get("coverage.colors.missed") || "rgb(245,32,32)",


### PR DESCRIPTION
Adds support for setting custom colors for covered, partial, missed lines.

Closes https://github.com/codecov/engineering-team/issues/2819

![Recording 2024-11-20 at 15 28 48](https://github.com/user-attachments/assets/1d5056e3-759a-4d00-ac26-9b9c22e60c7a)
