### PR TITLE
feat: Enable coverage feature by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
       "properties": {
         "codecov.coverage.enabled": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Toggle Codecov line coverage decorations.",
           "order": 0
         },


### PR DESCRIPTION
This PR sets the coverage feature toggle to be enabled by default.

Closes https://github.com/codecov/engineering-team/issues/2823
